### PR TITLE
fs: remove kernel cache refcount from inode

### DIFF
--- a/inode.cc
+++ b/inode.cc
@@ -6,7 +6,7 @@
 
 Inode::Inode(time_t time, uid_t uid, gid_t gid, blksize_t blksize,
     mode_t mode, BlockAllocator *ba) :
-    ino_set_(false), lookup_count_(0), ba_(ba)
+    ino_set_(false), ba_(ba)
 {
   memset(&i_st, 0, sizeof(i_st));
 
@@ -28,21 +28,6 @@ Inode::Inode(time_t time, uid_t uid, gid_t gid, blksize_t blksize,
 Inode::~Inode()
 {
   free_blocks(ba_);
-}
-
-bool Inode::lookup_get()
-{
-  assert(lookup_count_ >= 0);
-  lookup_count_++;
-  return lookup_count_ == 1;
-}
-
-bool Inode::lookup_put(long int dec)
-{
-  assert(lookup_count_);
-  lookup_count_ -= dec;
-  assert(lookup_count_ >= 0);
-  return lookup_count_ == 0;
 }
 
 void Inode::set_ino(fuse_ino_t ino)

--- a/inode.h
+++ b/inode.h
@@ -30,15 +30,11 @@ class Inode {
   bool is_directory() const;
   bool is_symlink() const;
 
-  bool lookup_get();
-  bool lookup_put(long int dec);
-
  private:
   void free_blocks(BlockAllocator *ba);
 
   bool ino_set_;
   fuse_ino_t ino_;
-  long int lookup_count_;
   BlockAllocator *ba_;
   std::vector<Block> blks_;
 };

--- a/inode_index.cc
+++ b/inode_index.cc
@@ -1,4 +1,5 @@
 #include "inode_index.h"
+#include <cassert>
 
 void InodeIndex::add(Inode::Ptr inode)
 {

--- a/inode_index.h
+++ b/inode_index.h
@@ -16,7 +16,8 @@ class InodeIndex {
   uint64_t nfiles();
 
  private:
-  std::unordered_map<fuse_ino_t, Inode::Ptr> refs_;
+  std::unordered_map<fuse_ino_t,
+    std::pair<long int, Inode::Ptr>> refs_;
 };
 
 #endif

--- a/inode_index.h
+++ b/inode_index.h
@@ -1,18 +1,37 @@
 #ifndef GASSYFS_INODE_INDEX_H_
 #define GASSYFS_INODE_INDEX_H_
-#include <cassert>
 #include <unordered_map>
 #include <fuse.h>
 #include "inode.h"
 
+/*
+ * This container maps inode number to inode pointer. Each inode has an
+ * associated reference count, and when the reference count falls to zero that
+ * inode is removed. The reference count corresponds to the number of
+ * outstanding references that the kernel inode cache has for an inode.
+ */
 class InodeIndex {
  public:
+  /*
+   * insert an inode into the index. this is the same as `get` but asserts
+   * that the inode is not in the index. reference counts start at one.
+   */
   void add(Inode::Ptr inode);
+
+  /*
+   * increase the reference count on an inode. if the inode isn't present in
+   * the index it is added with an initial count of one.
+   */
   void get(Inode::Ptr inode);
+
+  // decrease the reference count by given amount.
   void put(fuse_ino_t ino, long int dec);
+
+  // lookup inodes by type
   Inode::Ptr inode(fuse_ino_t ino);
   DirInode::Ptr dir_inode(fuse_ino_t ino);
   SymlinkInode::Ptr symlink_inode(fuse_ino_t ino);
+
   uint64_t nfiles();
 
  private:


### PR DESCRIPTION
This move the kernel inode cache reference counting into the inode index
structure. it was completely contained, so having the counts in the
inode served no purpose.

Signed-off-by: Noah Watkins <noahwatkins@gmail.com>